### PR TITLE
fix(tournament): prevent premature Grand Final creation

### DIFF
--- a/src/server/tournament-engine.test.ts
+++ b/src/server/tournament-engine.test.ts
@@ -1,0 +1,290 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  createTournament,
+  addPlayer,
+  startTournament,
+  processMatchResult,
+  toTournamentState,
+  type Tournament,
+} from './tournament-engine';
+
+describe('Tournament Engine - Bracket Generation', () => {
+  // Helper to add multiple players
+  function addPlayers(tournament: Tournament, count: number): string[] {
+    const ids: string[] = [];
+    for (let i = 1; i <= count; i++) {
+      const player = addPlayer(tournament, `Player ${i}`);
+      if (player) ids.push(player.id);
+    }
+    return ids;
+  }
+
+  // Helper to get active matches (not finished)
+  function getActiveMatches(tournament: Tournament) {
+    return [
+      ...tournament.winnersMatches.filter(m => m.phase !== 'finished'),
+      ...tournament.losersMatches.filter(m => m.phase !== 'finished'),
+    ];
+  }
+
+  test('4 players - basic bracket creation', () => {
+    const tournament = createTournament('gatos-caes');
+    const playerIds = addPlayers(tournament, 4);
+
+    expect(playerIds.length).toBe(4);
+    expect(startTournament(tournament)).toBe(true);
+
+    // Should create 2 matches in winners bracket round 1
+    expect(tournament.winnersMatches.length).toBe(2);
+    expect(tournament.losersMatches.length).toBe(0);
+    expect(tournament.grandFinal).toBeNull();
+  });
+
+  test('3 players - one bye in first round', () => {
+    const tournament = createTournament('gatos-caes');
+    const playerIds = addPlayers(tournament, 3);
+
+    startTournament(tournament);
+
+    // With 3 players: 1 match + 1 bye
+    // One player advances automatically with bye
+    expect(tournament.winnersMatches.length).toBe(1);
+    expect(tournament.winnersWaiting.length).toBe(1); // Player with bye
+  });
+
+  test('5 players - two byes to make even brackets', () => {
+    const tournament = createTournament('gatos-caes');
+    addPlayers(tournament, 5);
+
+    startTournament(tournament);
+
+    // With 5 players: 2 matches + 1 bye
+    expect(tournament.winnersMatches.length).toBe(2);
+    expect(tournament.winnersWaiting.length).toBe(1); // Player with bye
+  });
+
+  test('4 players - full tournament flow', () => {
+    const tournament = createTournament('gatos-caes');
+    addPlayers(tournament, 4);
+    startTournament(tournament);
+
+    // Round 1 Winners: Match 1 and Match 2
+    const [match1, match2] = tournament.winnersMatches;
+    const m1Winner = match1.player1!.id;
+    const m1Loser = match1.player2!.id;
+    const m2Winner = match2.player1!.id;
+    const m2Loser = match2.player2!.id;
+
+    // Complete Match 1
+    processMatchResult(tournament, match1.id, m1Winner);
+
+    // After first match, winner and loser should be waiting
+    // (no new matches created yet since Match 2 is still in progress)
+    expect(tournament.winnersWaiting).toContain(m1Winner);
+    expect(tournament.losersWaiting).toContain(m1Loser);
+    expect(tournament.grandFinal).toBeNull(); // Should NOT create grand final yet!
+
+    // Complete Match 2
+    processMatchResult(tournament, match2.id, m2Winner);
+
+    // Should have created Round 2 Winners and Round 1 Losers
+    expect(tournament.winnersMatches.length).toBe(3); // 2 R1 + 1 R2
+    expect(tournament.losersMatches.length).toBe(1);
+
+    // Winners Final (Match 3)
+    const winnersFinal = tournament.winnersMatches.find(m => m.phase === 'waiting')!;
+    processMatchResult(tournament, winnersFinal.id, m1Winner);
+
+    // Losers Round 1 (Match 4)
+    const losersR1 = tournament.losersMatches.find(m => m.phase === 'waiting')!;
+    processMatchResult(tournament, losersR1.id, m1Loser);
+
+    // Should have created Losers Final (m2Winner dropped + m1Loser advanced)
+    expect(tournament.losersMatches.length).toBe(2);
+
+    // Losers Final
+    const losersFinal = tournament.losersMatches.find(m => m.phase === 'waiting')!;
+    processMatchResult(tournament, losersFinal.id, m1Loser);
+
+    // Now Grand Final should exist
+    expect(tournament.grandFinal).not.toBeNull();
+    expect(tournament.grandFinal!.player1!.id).toBe(m1Winner); // Winners champion
+    expect(tournament.grandFinal!.player2!.id).toBe(m1Loser); // Losers champion
+  });
+
+  test('Grand Final should NOT be created while losers matches are in progress', () => {
+    const tournament = createTournament('gatos-caes');
+    addPlayers(tournament, 4);
+    startTournament(tournament);
+
+    const [match1, match2] = tournament.winnersMatches;
+    const m1Winner = match1.player1!.id;
+    const m1Loser = match1.player2!.id;
+    const m2Winner = match2.player1!.id;
+    const m2Loser = match2.player2!.id;
+
+    // Complete both round 1 matches
+    processMatchResult(tournament, match1.id, m1Winner);
+    processMatchResult(tournament, match2.id, m2Winner);
+
+    // Now we have Winners Final and Losers R1
+    const winnersFinal = tournament.winnersMatches.find(m => m.phase === 'waiting')!;
+    const losersR1 = tournament.losersMatches.find(m => m.phase === 'waiting')!;
+
+    expect(winnersFinal).toBeDefined();
+    expect(losersR1).toBeDefined();
+
+    // Complete Winners Final BEFORE Losers R1
+    processMatchResult(tournament, winnersFinal.id, m1Winner);
+
+    // At this point:
+    // - Winners bracket has a champion (m1Winner in winnersWaiting)
+    // - m2Winner dropped to losers
+    // - Losers R1 is STILL IN PROGRESS
+
+    // Grand Final should NOT exist yet because losers bracket isn't done
+    const activeMatches = getActiveMatches(tournament);
+    expect(activeMatches.length).toBeGreaterThan(0);
+    expect(tournament.grandFinal).toBeNull(); // This is the key assertion
+
+    // Now complete losers R1
+    processMatchResult(tournament, losersR1.id, m1Loser);
+
+    // Now we need losers final (m2Winner who dropped vs m1Loser who won losers R1)
+    const losersFinal = tournament.losersMatches.find(m => m.phase === 'waiting');
+    expect(losersFinal).toBeDefined();
+    expect(tournament.grandFinal).toBeNull(); // Still shouldn't exist
+
+    // Complete losers final
+    processMatchResult(tournament, losersFinal!.id, m1Loser);
+
+    // NOW Grand Final should exist
+    expect(tournament.grandFinal).not.toBeNull();
+    expect(tournament.grandFinal!.player1!.id).toBe(m1Winner); // Winners champion
+    expect(tournament.grandFinal!.player2!.id).toBe(m1Loser); // Losers champion
+  });
+
+  test('Grand Final Reset when losers champion wins', () => {
+    const tournament = createTournament('gatos-caes');
+    addPlayers(tournament, 2);
+    startTournament(tournament);
+
+    // Only 1 match in winners bracket
+    const match = tournament.winnersMatches[0];
+    const winnersChamp = match.player1!.id;
+    const losersChamp = match.player2!.id;
+
+    // Player 1 wins winners bracket
+    processMatchResult(tournament, match.id, winnersChamp);
+
+    // Grand Final should exist immediately (only 2 players)
+    expect(tournament.grandFinal).not.toBeNull();
+    expect(tournament.grandFinal!.player1!.id).toBe(winnersChamp);
+    expect(tournament.grandFinal!.player2!.id).toBe(losersChamp);
+
+    // Losers champion wins Grand Final
+    processMatchResult(tournament, tournament.grandFinal!.id, losersChamp);
+
+    // Grand Final Reset should exist
+    expect(tournament.grandFinalReset).not.toBeNull();
+    expect(tournament.phase).toBe('running');
+
+    // Winners champion wins the reset
+    processMatchResult(tournament, tournament.grandFinalReset!.id, winnersChamp);
+
+    // Tournament should be finished
+    expect(tournament.phase).toBe('finished');
+    expect(tournament.championId).toBe(winnersChamp);
+  });
+
+  test('2 players - simplest tournament', () => {
+    const tournament = createTournament('gatos-caes');
+    addPlayers(tournament, 2);
+    startTournament(tournament);
+
+    expect(tournament.winnersMatches.length).toBe(1);
+
+    const match = tournament.winnersMatches[0];
+    const winner = match.player1!.id;
+
+    processMatchResult(tournament, match.id, winner);
+
+    // With 2 players, after 1 match we go straight to Grand Final
+    expect(tournament.grandFinal).not.toBeNull();
+  });
+
+  test('8 players - power of 2, no byes', () => {
+    const tournament = createTournament('gatos-caes');
+    addPlayers(tournament, 8);
+    startTournament(tournament);
+
+    // Round 1: 4 matches
+    expect(tournament.winnersMatches.length).toBe(4);
+    expect(tournament.winnersWaiting.length).toBe(0); // No byes
+  });
+
+  test('Players lose count correctly through brackets', () => {
+    const tournament = createTournament('gatos-caes');
+    addPlayers(tournament, 4);
+    startTournament(tournament);
+
+    const [match1, match2] = tournament.winnersMatches;
+    const loserId = match1.player2!.id;
+
+    // Before any match
+    const loserBefore = tournament.playerById.get(loserId)!;
+    expect(loserBefore.losses).toBe(0);
+
+    // Lose in winners bracket
+    processMatchResult(tournament, match1.id, match1.player1!.id);
+    expect(tournament.playerById.get(loserId)!.losses).toBe(1);
+
+    // Complete match2 to create losers bracket
+    processMatchResult(tournament, match2.id, match2.player1!.id);
+
+    // Find and complete losers match where our player is
+    const losersMatch = tournament.losersMatches.find(
+      m => m.player1?.id === loserId || m.player2?.id === loserId
+    );
+
+    if (losersMatch) {
+      const winnerId = losersMatch.player1?.id === loserId
+        ? losersMatch.player2!.id
+        : losersMatch.player1!.id;
+
+      processMatchResult(tournament, losersMatch.id, winnerId);
+
+      // After losing in losers bracket
+      expect(tournament.playerById.get(loserId)!.losses).toBe(2);
+    }
+  });
+});
+
+describe('Tournament Engine - Edge Cases', () => {
+  test('Cannot start tournament with less than 2 players', () => {
+    const tournament = createTournament('gatos-caes');
+    addPlayer(tournament, 'Solo Player');
+
+    expect(startTournament(tournament)).toBe(false);
+    expect(tournament.phase).toBe('registration');
+  });
+
+  test('Cannot add players after tournament starts', () => {
+    const tournament = createTournament('gatos-caes');
+    addPlayer(tournament, 'Player 1');
+    addPlayer(tournament, 'Player 2');
+    startTournament(tournament);
+
+    const newPlayer = addPlayer(tournament, 'Late Player');
+    expect(newPlayer).toBeNull();
+  });
+
+  test('Cannot start tournament twice', () => {
+    const tournament = createTournament('gatos-caes');
+    addPlayer(tournament, 'Player 1');
+    addPlayer(tournament, 'Player 2');
+
+    expect(startTournament(tournament)).toBe(true);
+    expect(startTournament(tournament)).toBe(false);
+  });
+});

--- a/src/server/tournament-engine.ts
+++ b/src/server/tournament-engine.ts
@@ -408,10 +408,14 @@ export function processMatchResult(
   }
 
   // Verifica se é hora da grand final
+  // IMPORTANTE: Só cria grand final quando TODOS os matches terminaram
+  // e há exatamente 1 jogador em cada bracket
   if (
     tournament.winnersWaiting.length === 1 &&
     tournament.losersWaiting.length === 1 &&
-    !tournament.grandFinal
+    !tournament.grandFinal &&
+    allWinnersMatchesFinished &&
+    allLosersMatchesFinished
   ) {
     createGrandFinal(tournament);
     if (tournament.grandFinal) {


### PR DESCRIPTION
## Summary

Fixes a critical bug where Grand Final was created prematurely when only 1 player was in each waiting list, even if other matches were still in progress.

## The Bug

With 4 players:
1. Match 1 finishes → Winner to `winnersWaiting`, Loser to `losersWaiting`
2. Code checked: `winnersWaiting.length === 1 && losersWaiting.length === 1` → TRUE
3. Grand Final created immediately, **skipping Match 2 entirely!**

## The Fix

Added checks for `allWinnersMatchesFinished` and `allLosersMatchesFinished` to the Grand Final creation condition in `tournament-engine.ts:413-418`.

## Tests Added

Created `tournament-engine.test.ts` with 12 tests covering:
- Basic bracket creation (4, 3, 5, 8 players)
- Bye handling for non-power-of-2 players
- Full tournament flow
- Grand Final timing validation
- Grand Final Reset when losers champion wins
- Edge cases

## Test plan

- [x] All 250 project tests pass
- [x] New tournament engine tests verify the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)