### PR TITLE
fix(ai): fix AI loading issues across all games

### DIFF
--- a/src/games/atari-go/ai/atari-go.worker.ts
+++ b/src/games/atari-go/ai/atari-go.worker.ts
@@ -8,7 +8,7 @@ function post(msg: AIResponse) {
 }
 
 type WasmModule = {
-  default: (wasmUrl: URL) => Promise<void>;
+  default: (opts: { module_or_path: URL | string }) => Promise<void>;
   init: (seed: number) => void;
   set_position: (board: Uint8Array, toPlay: number) => void;
   best_move: (timeMs: number, level: number) => number;
@@ -23,7 +23,7 @@ async function init(): Promise<void> {
   try {
     const wasmModule = (await import('./wasm/pkg/atari_go_ai.js')) as WasmModule;
     const wasmUrl = new URL('./wasm/pkg/atari_go_ai_bg.wasm', import.meta.url);
-    await wasmModule.default(wasmUrl);
+    await wasmModule.default({ module_or_path: wasmUrl });
     wasmModule.init((Date.now() >>> 0) as number);
     wasm = wasmModule;
     useWasm = true;

--- a/src/games/gatos-caes/ai/ai-client.ts
+++ b/src/games/gatos-caes/ai/ai-client.ts
@@ -1,66 +1,24 @@
 /**
  * AI Client for Gatos & Cães
  *
- * Provides a simple interface to the AI engine, handling worker communication.
+ * Provides a simple interface to the AI engine.
+ * Uses direct/inline computation (no Web Worker) for better compatibility
+ * across different bundlers and environments.
  */
 
 import type { GatosCaesState, Posicao } from '../types';
-import type { WorkerRequest, WorkerResponse, SearchStats } from './types';
+import type { SearchStats } from './types';
+import { computeBestMove } from './engine';
 
-// Fallback: run engine directly if worker fails
-import { computeBestMove as computeBestMoveDirect } from './engine';
-
-let worker: Worker | null = null;
-let workerReady = false;
-let requestId = 0;
-let pendingResolve: ((result: { move: Posicao | null; stats: SearchStats }) => void) | null = null;
+let isReady = false;
 
 /**
- * Initialize the AI worker
+ * Initialize the AI (no-op, always ready)
  */
 export function initAI(): Promise<void> {
-  return new Promise((resolve, reject) => {
-    try {
-      // Try to create worker
-      worker = new Worker(
-        new URL('./gatos-caes.worker.ts', import.meta.url),
-        { type: 'module' }
-      );
-
-      worker.onmessage = (event) => {
-        const data = event.data;
-
-        if (data.type === 'ready') {
-          workerReady = true;
-          resolve();
-          return;
-        }
-
-        if (data.type === 'move_result' && pendingResolve) {
-          const response = data as WorkerResponse;
-          pendingResolve({ move: response.move, stats: response.stats });
-          pendingResolve = null;
-        }
-      };
-
-      worker.onerror = (error) => {
-        console.error('AI worker error:', error);
-        worker = null;
-        workerReady = false;
-        resolve(); // Still resolve, will fall back to sync
-      };
-
-      // Timeout for worker initialization
-      setTimeout(() => {
-        if (!workerReady) {
-          console.warn('AI worker timeout, using fallback');
-          resolve();
-        }
-      }, 3000);
-    } catch (error) {
-      console.warn('Failed to create AI worker, using fallback:', error);
-      resolve();
-    }
+  return new Promise((resolve) => {
+    isReady = true;
+    resolve();
   });
 }
 
@@ -71,61 +29,30 @@ export async function computeMove(
   state: GatosCaesState,
   difficulty: number = 3
 ): Promise<{ move: Posicao | null; stats: SearchStats }> {
-  // Use worker if available
-  if (worker && workerReady) {
-    return new Promise((resolve) => {
-      pendingResolve = resolve;
-      const id = ++requestId;
+  // Small yield to prevent UI blocking
+  await new Promise(resolve => setTimeout(resolve, 0));
 
-      const request: WorkerRequest = {
-        type: 'compute_move',
-        state,
-        difficulty,
-        requestId: id,
-      };
-
-      worker!.postMessage(request);
-
-      // Timeout fallback
-      setTimeout(() => {
-        if (pendingResolve === resolve) {
-          console.warn('Worker timeout, using fallback');
-          pendingResolve = null;
-          const result = computeBestMoveDirect(state, difficulty);
-          resolve(result);
-        }
-      }, 30000); // 30 second timeout
-    });
-  }
-
-  // Fallback: run synchronously
-  return computeBestMoveDirect(state, difficulty);
+  // Run computation directly
+  return computeBestMove(state, difficulty);
 }
 
 /**
- * Cancel ongoing computation
+ * Cancel ongoing computation (no-op for inline computation)
  */
 export function cancelComputation(): void {
-  if (worker && workerReady) {
-    worker.postMessage({ type: 'cancel' });
-  }
-  pendingResolve = null;
+  // No-op - inline computation can't be cancelled
 }
 
 /**
- * Terminate the AI worker
+ * Terminate the AI (no-op)
  */
 export function terminateAI(): void {
-  if (worker) {
-    worker.terminate();
-    worker = null;
-    workerReady = false;
-  }
+  isReady = false;
 }
 
 /**
  * Check if AI is ready
  */
 export function isAIReady(): boolean {
-  return workerReady || true; // Always ready with fallback
+  return isReady;
 }

--- a/src/games/nex/ai/nex.worker.ts
+++ b/src/games/nex/ai/nex.worker.ts
@@ -6,7 +6,7 @@ function post(msg: AIResponse) {
 }
 
 type WasmModule = {
-  default: (wasmUrl: URL) => Promise<void>;
+  default: (opts: { module_or_path: URL | string }) => Promise<void>;
   choose_move: (board: Uint8Array, toPlay: number, flags: number, msBudget: number, level: number, seed: number) => any;
   debug_eval?: (board: Uint8Array, toPlay: number, flags: number) => any;
 };
@@ -19,7 +19,7 @@ async function init(): Promise<void> {
   try {
     const wasmModule = (await import('./wasm/pkg/nex_ai.js')) as WasmModule;
     const wasmUrl = new URL('./wasm/pkg/nex_ai_bg.wasm', import.meta.url);
-    await wasmModule.default(wasmUrl);
+    await wasmModule.default({ module_or_path: wasmUrl });
     wasm = wasmModule;
     useWasm = true;
     console.log('[NexAI] WASM engine initialized');

--- a/src/games/produto/ai/produto.worker.ts
+++ b/src/games/produto/ai/produto.worker.ts
@@ -6,7 +6,7 @@ function post(msg: AIResponse) {
 }
 
 type WasmModule = {
-  default: (wasmUrl: URL) => Promise<void>;
+  default: (opts: { module_or_path: URL | string }) => Promise<void>;
   init_ai: (seed: number) => void;
   choose_move: (state: any, cfg: any) => any;
   explain_last: () => string;
@@ -20,7 +20,7 @@ async function init(): Promise<void> {
   try {
     const wasmModule = (await import('./wasm/pkg/produto_ai.js')) as WasmModule;
     const wasmUrl = new URL('./wasm/pkg/produto_ai_bg.wasm', import.meta.url);
-    await wasmModule.default(wasmUrl);
+    await wasmModule.default({ module_or_path: wasmUrl });
     wasmModule.init_ai((Date.now() >>> 0) as number);
     wasm = wasmModule;
     useWasm = true;

--- a/src/games/quelhas/ai/quelhas.worker.ts
+++ b/src/games/quelhas/ai/quelhas.worker.ts
@@ -81,7 +81,8 @@ async function init(): Promise<void> {
     // wasm-bindgen foi gerado com `--omit-default-module-path`, por isso temos de
     // indicar explicitamente onde está o .wasm.
     wasmUrl = new URL('./wasm/pkg/quelhas_wasm_bg.wasm', import.meta.url);
-    await wasmModule.default(wasmUrl);
+    // Use new wasm-bindgen init syntax (object parameter instead of URL directly)
+    await wasmModule.default({ module_or_path: wasmUrl });
     wasmEngine = new wasmModule.QuelhasEngine(18);
     useWasm = true;
     console.log('[QuelhasAI] WASM engine initialized');


### PR DESCRIPTION
## Summary

Fixes AI loading errors in production builds:

- **Gatos & Cães**: Remove Web Worker usage, use direct/inline computation instead for better compatibility across bundlers. Web Workers were causing "AI worker error: Event" errors.

- **All WASM workers**: Update wasm-bindgen init calls to use new object parameter syntax (`{ module_or_path: url }`) instead of deprecated direct URL parameter. This fixes the "using deprecated parameters for the initialization function; pass a single object instead" warnings.

## Files Changed

- `src/games/gatos-caes/ai/ai-client.ts` - Simplified to use direct computation
- `src/games/quelhas/ai/quelhas.worker.ts` - Fixed WASM init syntax
- `src/games/nex/ai/nex.worker.ts` - Fixed WASM init syntax  
- `src/games/produto/ai/produto.worker.ts` - Fixed WASM init syntax
- `src/games/atari-go/ai/atari-go.worker.ts` - Fixed WASM init syntax

## Test plan

- [x] All 263 tests pass
- [ ] Test Gatos & Cães AI in browser
- [ ] Test Quelhas AI in browser (should no longer timeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)