### PR TITLE
feat: add game spectator view to admin panel

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -666,7 +666,7 @@ if (existsSync(outdir)) {
 
 const start = performance.now();
 
-const entrypoints = [...new Bun.Glob("**.html").scanSync("src")]
+const entrypoints = [...new Bun.Glob("**/*.html").scanSync("src")]
   .map(a => path.resolve("src", a))
   .filter(dir => !dir.includes("node_modules"));
 console.log(`📄 Found ${entrypoints.length} HTML ${entrypoints.length === 1 ? "file" : "files"} to process\n`);
@@ -678,6 +678,12 @@ const result = await Bun.build({
   minify: true,
   target: "browser",
   sourcemap: "linked",
+  splitting: true,
+  naming: {
+    entry: "[dir]/[name].[ext]",
+    chunk: "chunks/[name]-[hash].[ext]",
+    asset: "assets/[name]-[hash].[ext]",
+  },
   define: {
     "process.env.NODE_ENV": JSON.stringify("production"),
   },

--- a/src/admin/AdminSpectatorPage.tsx
+++ b/src/admin/AdminSpectatorPage.tsx
@@ -1,0 +1,313 @@
+/**
+ * Página de espectador para o painel de administração.
+ * Mostra jogos em curso e permite visualizar tabuleiros em tempo real.
+ */
+
+import { createRoot } from 'react-dom/client';
+import { useState, useEffect, useRef } from 'react';
+import type { GameId, BracketType, MatchScore } from '../tournament/protocol';
+import {
+  GatosCaesBoard,
+  DominorioBoard,
+  QuelhasBoard,
+  ProdutoBoard,
+  AtariGoBoard,
+  NexBoard,
+} from '../tournament/GameBoards';
+
+// Tipos para os estados
+interface ActiveGameInfo {
+  matchId: string;
+  bracket: BracketType | 'grandFinal' | 'grandFinalReset';
+  round: number;
+  player1Name: string;
+  player2Name: string;
+  score: MatchScore;
+  gameNumber: number;
+}
+
+interface SpectatorMatchState {
+  matchId: string;
+  gameNumber: number;
+  gameState: unknown;
+  bracket: BracketType | 'grandFinal' | 'grandFinalReset';
+  round: number;
+  player1Name: string;
+  player2Name: string;
+  score: MatchScore;
+  whoseTurn: 'player1' | 'player2' | null;
+}
+
+// Componente principal
+function AdminSpectatorPage() {
+  const urlParams = new URLSearchParams(window.location.search);
+  const initialMatchId = urlParams.get('matchId');
+  const gameIdParam = urlParams.get('gameId') as GameId | null;
+
+  const [activeGames, setActiveGames] = useState<ActiveGameInfo[]>([]);
+  const [selectedMatchId, setSelectedMatchId] = useState<string | null>(initialMatchId);
+  const [matchState, setMatchState] = useState<SpectatorMatchState | null>(null);
+  const [gameId, setGameId] = useState<GameId | null>(gameIdParam);
+  const [connected, setConnected] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const wsRef = useRef<WebSocket | null>(null);
+
+  // Conexao WebSocket
+  useEffect(() => {
+    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    const wsUrl = `${protocol}//${window.location.host}/ws`;
+
+    const connect = () => {
+      const ws = new WebSocket(wsUrl);
+      wsRef.current = ws;
+
+      ws.onopen = () => {
+        setConnected(true);
+        setError(null);
+      };
+
+      ws.onmessage = (event) => {
+        try {
+          const msg = JSON.parse(event.data);
+
+          if (msg.type === 'active_games_list') {
+            setActiveGames(msg.games || []);
+          }
+
+          if (msg.type === 'spectator_game_state') {
+            // Actualiza se for o match selecionado ou se nenhum está selecionado ainda
+            if (msg.matchId === selectedMatchId || !selectedMatchId) {
+              setMatchState({
+                matchId: msg.matchId,
+                gameNumber: msg.gameNumber,
+                gameState: msg.gameState,
+                bracket: msg.bracket,
+                round: msg.round,
+                player1Name: msg.player1Name,
+                player2Name: msg.player2Name,
+                score: msg.score,
+                whoseTurn: msg.whoseTurn,
+              });
+              // Se não havia match selecionado, seleciona este
+              if (!selectedMatchId) {
+                setSelectedMatchId(msg.matchId);
+              }
+            }
+          }
+
+          // Extrair gameId do tournament_state_update
+          if (msg.type === 'tournament_state_update' && msg.gameId) {
+            setGameId(msg.gameId);
+          }
+        } catch (e) {
+          console.error('Erro ao processar mensagem:', e);
+        }
+      };
+
+      ws.onerror = () => {
+        setError('Erro na conexao WebSocket');
+        setConnected(false);
+      };
+
+      ws.onclose = () => {
+        setConnected(false);
+        // Tentar reconectar após 3 segundos
+        setTimeout(connect, 3000);
+      };
+    };
+
+    connect();
+
+    return () => {
+      if (wsRef.current) {
+        wsRef.current.close();
+      }
+    };
+  }, []);
+
+  // Atualizar matchState quando selectedMatchId muda
+  useEffect(() => {
+    if (selectedMatchId && matchState && matchState.matchId !== selectedMatchId) {
+      // Limpar estado antigo ao trocar de match
+      setMatchState(null);
+    }
+  }, [selectedMatchId]);
+
+  // Renderizar tabuleiro baseado no gameId
+  const renderBoard = () => {
+    if (!matchState || !matchState.gameState || !gameId) {
+      return (
+        <div className="flex items-center justify-center h-64 text-white/50">
+          <p>A aguardar dados do jogo...</p>
+        </div>
+      );
+    }
+
+    const state = matchState.gameState as any;
+    const commonProps = {
+      isMyTurn: false,
+      myRole: 'jogador1' as const,
+      onMove: () => {},
+    };
+
+    switch (gameId) {
+      case 'gatos-caes':
+        return <GatosCaesBoard state={state} {...commonProps} />;
+      case 'dominorio':
+        return <DominorioBoard state={state} {...commonProps} />;
+      case 'quelhas':
+        return <QuelhasBoard state={state} {...commonProps} />;
+      case 'produto':
+        return <ProdutoBoard state={state} {...commonProps} />;
+      case 'atari-go':
+        return <AtariGoBoard state={state} {...commonProps} />;
+      case 'nex':
+        return <NexBoard state={state} {...commonProps} />;
+      default:
+        return <div className="text-white/50">Jogo desconhecido: {gameId}</div>;
+    }
+  };
+
+  const getBracketLabel = (bracket: BracketType | 'grandFinal' | 'grandFinalReset') => {
+    switch (bracket) {
+      case 'winners': return 'Winners';
+      case 'losers': return 'Losers';
+      case 'grandFinal': return 'Grande Final';
+      case 'grandFinalReset': return 'Final Reset';
+      default: return bracket;
+    }
+  };
+
+  const getBracketColor = (bracket: BracketType | 'grandFinal' | 'grandFinalReset') => {
+    switch (bracket) {
+      case 'winners': return 'bg-green-500/20 text-green-400 border-green-500/30';
+      case 'losers': return 'bg-orange-500/20 text-orange-400 border-orange-500/30';
+      case 'grandFinal':
+      case 'grandFinalReset': return 'bg-yellow-500/20 text-yellow-400 border-yellow-500/30';
+      default: return 'bg-gray-500/20 text-gray-400 border-gray-500/30';
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-900 text-white p-4">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="text-lg font-bold">Admin Spectator</h1>
+        <div className={`px-2 py-1 rounded text-xs ${connected ? 'bg-green-500/20 text-green-400' : 'bg-red-500/20 text-red-400'}`}>
+          {connected ? 'Conectado' : 'Desconectado'}
+        </div>
+      </div>
+
+      {error && (
+        <div className="bg-red-500/20 border border-red-500/30 rounded-lg p-3 mb-4 text-red-300 text-sm">
+          {error}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 lg:grid-cols-4 gap-4">
+        {/* Lista de jogos */}
+        <div className="lg:col-span-1 bg-gray-800/50 rounded-xl p-3 border border-white/10">
+          <h2 className="text-sm font-semibold mb-3 text-white/70">Jogos em Curso ({activeGames.length})</h2>
+
+          {activeGames.length === 0 ? (
+            <p className="text-white/40 text-sm">Nenhum jogo em curso</p>
+          ) : (
+            <div className="space-y-2">
+              {activeGames.map((game) => (
+                <button
+                  key={game.matchId}
+                  onClick={() => setSelectedMatchId(game.matchId)}
+                  className={`w-full text-left p-2 rounded-lg transition-all ${
+                    selectedMatchId === game.matchId
+                      ? 'bg-blue-500/20 border border-blue-500/50'
+                      : 'bg-white/5 border border-white/10 hover:bg-white/10'
+                  }`}
+                >
+                  <div className="flex items-center justify-between mb-1">
+                    <span className={`text-[10px] px-1.5 py-0.5 rounded border ${getBracketColor(game.bracket)}`}>
+                      {getBracketLabel(game.bracket)}
+                    </span>
+                    <span className="text-[10px] text-white/40">R{game.round}</span>
+                  </div>
+                  <div className="text-sm font-medium truncate">
+                    {game.player1Name} vs {game.player2Name}
+                  </div>
+                  <div className="flex items-center justify-between mt-1">
+                    <span className="text-xs">
+                      <span className="text-green-400">{game.score.player1Wins}</span>
+                      <span className="text-white/30"> - </span>
+                      <span className="text-red-400">{game.score.player2Wins}</span>
+                    </span>
+                    <span className="text-[10px] text-white/40">Jogo {game.gameNumber}</span>
+                  </div>
+                  {selectedMatchId === game.matchId && (
+                    <div className="text-[10px] text-blue-400 mt-1">A observar</div>
+                  )}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Visualizador do jogo */}
+        <div className="lg:col-span-3 bg-gray-800/50 rounded-xl p-4 border border-white/10">
+          {selectedMatchId && matchState ? (
+            <>
+              {/* Info do match */}
+              <div className="flex items-center justify-between mb-4">
+                <div>
+                  <div className="flex items-center gap-2 mb-1">
+                    <span className={`text-xs px-2 py-0.5 rounded border ${getBracketColor(matchState.bracket)}`}>
+                      {getBracketLabel(matchState.bracket)} - Ronda {matchState.round}
+                    </span>
+                    <span className="text-xs text-white/40">Jogo {matchState.gameNumber}</span>
+                  </div>
+                  <h3 className="text-lg font-bold">
+                    {matchState.player1Name} vs {matchState.player2Name}
+                  </h3>
+                </div>
+                <div className="text-right">
+                  <div className="text-2xl font-bold">
+                    <span className="text-green-400">{matchState.score.player1Wins}</span>
+                    <span className="text-white/30 mx-2">-</span>
+                    <span className="text-red-400">{matchState.score.player2Wins}</span>
+                  </div>
+                  {matchState.whoseTurn && (
+                    <div className="text-xs text-white/50">
+                      Vez de: {matchState.whoseTurn === 'player1' ? matchState.player1Name : matchState.player2Name}
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              {/* Tabuleiro */}
+              <div className="bg-gradient-to-br from-gray-700/50 to-gray-800/50 rounded-xl p-4">
+                {renderBoard()}
+              </div>
+
+              {/* Aviso de modo espectador */}
+              <div className="mt-3 text-center text-xs text-white/40 bg-white/5 py-2 rounded-lg">
+                Modo espectador - apenas a observar
+              </div>
+            </>
+          ) : (
+            <div className="flex flex-col items-center justify-center h-64 text-white/40">
+              <svg className="w-12 h-12 mb-3 opacity-50" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+              </svg>
+              <p>Seleciona um jogo para observar</p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// Mount
+const rootEl = document.getElementById('root');
+if (rootEl) {
+  createRoot(rootEl).render(<AdminSpectatorPage />);
+}

--- a/src/admin/spectator.html
+++ b/src/admin/spectator.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Admin Spectator - CRJM</title>
+  <link rel="stylesheet" href="../index.css" />
+</head>
+<body class="bg-gray-900 min-h-screen">
+  <div id="root"></div>
+  <script type="module" src="./AdminSpectatorPage.tsx"></script>
+</body>
+</html>

--- a/src/server/admin-page.ts
+++ b/src/server/admin-page.ts
@@ -872,8 +872,94 @@ export function getAdminPageHtml(adminKey: string): string {
       border-left: 1px solid rgba(255,255,255,0.1);
     }
     
+    /* ========== ACTIVE GAMES LIST ========== */
+
+    .active-game-item {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      padding: 12px;
+      background: rgba(255,255,255,0.05);
+      border: 1px solid rgba(255,255,255,0.1);
+      border-radius: 10px;
+      margin-bottom: 10px;
+      cursor: pointer;
+      transition: all 0.2s;
+    }
+
+    .active-game-item:hover {
+      background: rgba(255,255,255,0.1);
+      border-color: rgba(34, 197, 94, 0.5);
+      transform: translateX(3px);
+    }
+
+    .active-game-item.watching {
+      border-color: #22c55e;
+      background: rgba(34, 197, 94, 0.15);
+    }
+
+    .active-game-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .active-game-bracket {
+      font-size: 0.7rem;
+      padding: 2px 8px;
+      border-radius: 8px;
+      font-weight: 600;
+    }
+
+    .bracket-winners {
+      background: rgba(34, 197, 94, 0.2);
+      color: #4ade80;
+    }
+
+    .bracket-losers {
+      background: rgba(245, 158, 11, 0.2);
+      color: #fbbf24;
+    }
+
+    .bracket-final {
+      background: rgba(255, 215, 0, 0.2);
+      color: #FFD700;
+    }
+
+    .active-game-players {
+      font-weight: 600;
+      font-size: 0.95rem;
+    }
+
+    .active-game-score {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 0.85rem;
+    }
+
+    .active-game-score .score-value {
+      font-weight: 700;
+    }
+
+    .active-game-score .score-p1 {
+      color: #4ade80;
+    }
+
+    .active-game-score .score-p2 {
+      color: #f87171;
+    }
+
+    .active-game-watching {
+      font-size: 0.7rem;
+      color: #22c55e;
+      display: flex;
+      align-items: center;
+      gap: 4px;
+    }
+
     /* ========== RESPONSIVE ========== */
-    
+
     @media (max-width: 900px) {
       .grid {
         grid-template-columns: 1fr;
@@ -950,6 +1036,28 @@ export function getAdminPageHtml(adminKey: string): string {
           </div>
         </div>
         
+        <div class="card" id="active-games-card">
+          <h2>
+            <span class="title-left"><span class="emoji">🎮</span> Jogos em Curso</span>
+            <span id="activeGamesCount" style="font-size: 0.8rem; color: rgba(255,255,255,0.5);">(0)</span>
+          </h2>
+          <div id="active-games-list">
+            <div class="no-data">Nenhum jogo em curso</div>
+          </div>
+        </div>
+
+        <div class="card" id="game-viewer-card" style="display: none; grid-column: 1 / -1;">
+          <h2>
+            <span class="title-left"><span class="emoji">📺</span> Visualizar Jogo</span>
+            <button class="btn-secondary btn-icon" onclick="closeGameViewer()" title="Fechar">✕</button>
+          </h2>
+          <iframe
+            id="game-viewer-iframe"
+            src=""
+            style="width: 100%; height: 600px; border: none; border-radius: 8px; background: #1a1a2e;"
+          ></iframe>
+        </div>
+
         <div class="card" style="grid-column: 1 / -1;">
           <h2><span class="title-left"><span class="emoji">📋</span> Logs de Eventos</span></h2>
           <div class="logs-container" id="logs">
@@ -2291,8 +2399,121 @@ Pedro Costa"></textarea>
       }
     });
     
+    // ========== SPECTATOR WEBSOCKET ==========
+
+    let spectatorWs = null;
+    let activeGames = [];
+    let watchingMatchId = null;
+
+    function connectSpectatorWs() {
+      const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+      const wsUrl = protocol + '//' + window.location.host + '/ws';
+
+      spectatorWs = new WebSocket(wsUrl);
+
+      spectatorWs.onopen = () => {
+        console.log('[Spectator] WebSocket connected');
+      };
+
+      spectatorWs.onmessage = (event) => {
+        try {
+          const msg = JSON.parse(event.data);
+
+          if (msg.type === 'active_games_list') {
+            activeGames = msg.games || [];
+            renderActiveGamesList();
+          }
+        } catch (e) {
+          console.error('[Spectator] Error parsing message:', e);
+        }
+      };
+
+      spectatorWs.onerror = (error) => {
+        console.error('[Spectator] WebSocket error:', error);
+      };
+
+      spectatorWs.onclose = () => {
+        console.log('[Spectator] WebSocket closed, reconnecting in 3s...');
+        setTimeout(connectSpectatorWs, 3000);
+      };
+    }
+
+    function renderActiveGamesList() {
+      const container = document.getElementById('active-games-list');
+      const countEl = document.getElementById('activeGamesCount');
+
+      countEl.textContent = '(' + activeGames.length + ')';
+
+      if (activeGames.length === 0) {
+        container.innerHTML = '<div class="no-data" style="padding: 15px;">Nenhum jogo em curso</div>';
+        return;
+      }
+
+      container.innerHTML = activeGames.map(game => {
+        const bracketClass = game.bracket === 'winners' ? 'bracket-winners' :
+                            game.bracket === 'losers' ? 'bracket-losers' : 'bracket-final';
+        const bracketLabel = game.bracket === 'winners' ? 'Winners' :
+                            game.bracket === 'losers' ? 'Losers' :
+                            game.bracket === 'grandFinal' ? 'Grand Final' : 'Final Reset';
+        const isWatching = watchingMatchId === game.matchId;
+
+        return '<div class="active-game-item' + (isWatching ? ' watching' : '') + '" onclick="watchGame(\\'' + game.matchId + '\\')">' +
+          '<div class="active-game-header">' +
+            '<span class="active-game-bracket ' + bracketClass + '">' + bracketLabel + ' R' + game.round + '</span>' +
+            '<span style="font-size: 0.75rem; color: rgba(255,255,255,0.4);">Jogo ' + game.gameNumber + '</span>' +
+          '</div>' +
+          '<div class="active-game-players">' + game.player1Name + ' vs ' + game.player2Name + '</div>' +
+          '<div class="active-game-score">' +
+            '<span class="score-value score-p1">' + game.score.player1Wins + '</span>' +
+            '<span style="color: rgba(255,255,255,0.3);">-</span>' +
+            '<span class="score-value score-p2">' + game.score.player2Wins + '</span>' +
+            (isWatching ? '<span class="active-game-watching"><span>👁️</span> A observar</span>' : '') +
+          '</div>' +
+        '</div>';
+      }).join('');
+    }
+
+    function watchGame(matchId) {
+      const iframe = document.getElementById('game-viewer-iframe');
+      const card = document.getElementById('game-viewer-card');
+
+      // Get current tournament gameId from cached tournaments
+      let gameId = 'gatos-caes'; // default
+      if (cachedTournaments.length > 0) {
+        const runningTournament = cachedTournaments.find(t => t.phase === 'running');
+        if (runningTournament) {
+          gameId = runningTournament.gameId;
+        } else {
+          gameId = cachedTournaments[0].gameId;
+        }
+      }
+
+      watchingMatchId = matchId;
+      iframe.src = '/admin/spectator?matchId=' + matchId + '&gameId=' + gameId;
+      card.style.display = 'block';
+
+      // Scroll to iframe
+      card.scrollIntoView({ behavior: 'smooth', block: 'start' });
+
+      // Re-render list to show watching indicator
+      renderActiveGamesList();
+    }
+
+    function closeGameViewer() {
+      const card = document.getElementById('game-viewer-card');
+      const iframe = document.getElementById('game-viewer-iframe');
+
+      card.style.display = 'none';
+      iframe.src = '';
+      watchingMatchId = null;
+
+      // Re-render list to remove watching indicator
+      renderActiveGamesList();
+    }
+
     // ========== INIT ==========
-    
+
+    connectSpectatorWs();
     refresh();
     startAutoRefresh();
   </script>

--- a/src/server/tournament-server.ts
+++ b/src/server/tournament-server.ts
@@ -1105,6 +1105,37 @@ async function handleHttpRequest(req: Request): Promise<Response> {
     });
   }
 
+  // Admin spectator page
+  if (url.pathname === '/admin/spectator') {
+    try {
+      // Try to serve from dist first (production)
+      const distPath = './dist/admin/spectator.html';
+      const srcPath = './src/admin/spectator.html';
+      const file = Bun.file(distPath);
+      if (await file.exists()) {
+        return new Response(await file.text(), {
+          headers: {
+            'Content-Type': 'text/html; charset=utf-8',
+            ...corsHeaders,
+          },
+        });
+      }
+      // Fallback to src (development)
+      const srcFile = Bun.file(srcPath);
+      if (await srcFile.exists()) {
+        return new Response(await srcFile.text(), {
+          headers: {
+            'Content-Type': 'text/html; charset=utf-8',
+            ...corsHeaders,
+          },
+        });
+      }
+      return new Response('Admin spectator page not found', { status: 404 });
+    } catch (e) {
+      return new Response('Error loading admin spectator page', { status: 500 });
+    }
+  }
+
   // Listar torneios
   if (url.pathname === '/api/tournaments') {
     return Response.json(
@@ -1651,6 +1682,33 @@ async function handleHttpRequest(req: Request): Promise<Response> {
     broadcastTournamentState(tournament);
 
     return Response.json({ success: true, message: 'Match reiniciado (0-0)' }, { headers: corsHeaders });
+  }
+
+  // Serve static files from dist/ for admin spectator page
+  if (
+    url.pathname.startsWith('/chunks/') ||
+    url.pathname.startsWith('/assets/') ||
+    url.pathname.endsWith('.js') ||
+    url.pathname.endsWith('.css') ||
+    url.pathname.endsWith('.svg')
+  ) {
+    const filePath = `./dist${url.pathname}`;
+    const file = Bun.file(filePath);
+
+    if (await file.exists()) {
+      const contentType = url.pathname.endsWith('.js') ? 'application/javascript'
+        : url.pathname.endsWith('.css') ? 'text/css'
+        : url.pathname.endsWith('.svg') ? 'image/svg+xml'
+        : url.pathname.endsWith('.html') ? 'text/html'
+        : 'application/octet-stream';
+
+      return new Response(await file.arrayBuffer(), {
+        headers: {
+          'Content-Type': contentType,
+          ...corsHeaders,
+        },
+      });
+    }
   }
 
   return new Response('Not Found', { status: 404, headers: corsHeaders });


### PR DESCRIPTION
- Add AdminSpectatorPage.tsx with real-time game viewing via WebSocket
- Add Jogos em Curso section to admin panel with active games list
- Add iframe integration to watch games from admin panel
- Add /admin/spectator route and static file serving to tournament server
- Fix build.ts glob pattern and configure naming for multiple entrypoints

Allows tournament administrators to watch ongoing matches in real-time directly from the admin panel.