### PR TITLE
docs(vnext): documentar túnel permanente crjm.infantinho.xyz

### DIFF
--- a/TORNEIO.md
+++ b/TORNEIO.md
@@ -20,7 +20,7 @@ Este guia explica como organizar um torneio de dupla eliminação para os teus a
 │          (ngrok / Cloudflare Tunnel)                         │
 │                                                              │
 │  Expõe o servidor local como HTTPS público                   │
-│  Ex: https://abc123.ngrok.io ou https://torneio.exemplo.com  │
+│  Ex: https://crjm.infantinho.xyz (túnel permanente)          │
 └─────────────────────────────────────────────────────────────┘
                               │
                               │ http://localhost:4000
@@ -47,15 +47,16 @@ Este guia explica como organizar um torneio de dupla eliminação para os teus a
    powershell -c "irm bun.sh/install.ps1 | iex"
    ```
 
-2. **ngrok** ou **Cloudflare Tunnel** para expor o servidor
+2. **Cloudflare Tunnel** (ou ngrok) para expor o servidor
    ```bash
-   # ngrok (mais simples, grátis para uso básico)
-   # Instalar em: https://ngrok.com/download
-   
-   # ou Cloudflare Tunnel (grátis, mais estável)
+   # Cloudflare Tunnel (grátis, estável) — no MacBook do Igor já está
+   # instalado e existe um túnel permanente para crjm.infantinho.xyz
+   # (ver docs/deployment/tunnel-crjm-infantinho.md)
    # macOS
    brew install cloudflare/cloudflare/cloudflared
    # Outros: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/
+
+   # alternativa: ngrok — https://ngrok.com/download
    ```
 
 ## Passo a Passo - Dia do Torneio
@@ -86,7 +87,33 @@ Deves ver algo como:
 
 ### 2. Expor o servidor (noutra janela de terminal)
 
-#### Opção A: ngrok (mais simples)
+#### Opção A: túnel permanente crjm.infantinho.xyz (recomendado)
+
+Já existe um Cloudflare Tunnel dedicado que mapeia **https://crjm.infantinho.xyz**
+para a porta 4000 local — o URL é fixo, não muda entre sessões:
+
+```bash
+cloudflared tunnel --config ~/.cloudflared/config-crjm.yml run
+```
+
+Quando o log mostrar `Registered tunnel connection`, os alunos usam
+`https://crjm.infantinho.xyz`. Detalhes de criação, diagnóstico e remoção em
+[docs/deployment/tunnel-crjm-infantinho.md](docs/deployment/tunnel-crjm-infantinho.md).
+
+Quando abrires `http://localhost:4000/admin` (ou o URL público equivalente), o browser vai pedir:
+
+- **utilizador**: `admin`
+- **palavra-passe**: o valor de `ADMIN_KEY`
+
+#### Opção B: túnel efémero Cloudflare (sem configuração)
+```bash
+cloudflared tunnel --url http://localhost:4000
+```
+
+Imprime um URL descartável tipo `https://random-words.trycloudflare.com` — útil como
+fallback, mas muda a cada execução.
+
+#### Opção C: ngrok
 ```bash
 ngrok http 4000
 ```
@@ -96,25 +123,11 @@ Resultado:
 Forwarding  https://abc123.ngrok.io -> http://localhost:4000
 ```
 
-Anota o URL `https://abc123.ngrok.io` - este é o URL que os alunos vão usar!
-
-Quando abrires `http://localhost:4000/admin` (ou o URL público equivalente), o browser vai pedir:
-
-- **utilizador**: `admin`
-- **palavra-passe**: o valor de `ADMIN_KEY`
-
-#### Opção B: Cloudflare Tunnel (mais estável)
-```bash
-cloudflared tunnel --url http://localhost:4000
-```
-
-Resultado similar, com um URL como `https://random-words.trycloudflare.com`
-
 ### 3. Testar a ligação
 
 1. Abre o painel de administração:
    - Local: http://localhost:4000/admin
-   - Ou pelo túnel: https://abc123.ngrok.io/admin
+   - Ou pelo túnel: https://crjm.infantinho.xyz/admin
 
 2. Verifica que aparece "Servidor ativo" no topo
 
@@ -130,8 +143,8 @@ Diz aos alunos para:
    - Jogo (ex: Gatos & Cães)
 4. **Desligar** o toggle "Modo de teste"
 5. Introduzir o endereço do servidor:
-   - Se usas ngrok: `wss://abc123.ngrok.io` (nota o `wss://` no início!)
-   - Se usas Cloudflare: `wss://random-words.trycloudflare.com`
+   - Túnel permanente: `wss://crjm.infantinho.xyz` (nota o `wss://` no início!)
+   - Se usas um túnel efémero/ngrok: `wss://<url-do-túnel>`
 6. Clicar em "Entrar no Campeonato"
 
 ### 5. Iniciar o torneio

--- a/docs/deployment/tunnel-crjm-infantinho.md
+++ b/docs/deployment/tunnel-crjm-infantinho.md
@@ -1,0 +1,119 @@
+# Túnel Cloudflare — crjm.infantinho.xyz
+
+Documenta a criação e operação do túnel permanente que expõe o servidor de torneios
+(`bun run tournament`, porta 4000) em **https://crjm.infantinho.xyz**.
+
+Criado a 2026-07-10 no MacBook do Igor. Estado: ativo e verificado.
+
+## Arquitetura
+
+```
+alunos/professor ──https──> Cloudflare (proxy + TLS)
+                                 │  CNAME crjm.infantinho.xyz → fcb1352b-….cfargotunnel.com
+                                 ▼
+                    cloudflared (conector local, QUIC de saída)
+                                 │  ingress: crjm.infantinho.xyz → http://127.0.0.1:4000
+                                 ▼
+                    servidor de torneios (Bun, HTTP + WebSocket na mesma porta)
+```
+
+Não há portas abertas no router: o `cloudflared` estabelece ligações de saída para a
+edge da Cloudflare. HTTP, WebSocket (`/ws`) e os ficheiros estáticos passam todos pelo
+mesmo hostname.
+
+## Identificadores
+
+| Item | Valor |
+| --- | --- |
+| Tunnel | `crjm` — UUID `fcb1352b-898e-4f0e-b96d-967e9a7e74e9` |
+| Hostname | `crjm.infantinho.xyz` (CNAME proxied para `<UUID>.cfargotunnel.com`) |
+| Config do conector | `~/.cloudflared/config-crjm.yml` |
+| Credenciais do tunnel | `~/.cloudflared/fcb1352b-898e-4f0e-b96d-967e9a7e74e9.json` (secreto) |
+| Serviço de origem | `http://127.0.0.1:4000` |
+| `ADMIN_KEY` | `.env.local` na raiz do repo (gitignored, chmod 600) |
+
+Na mesma máquina corre um segundo túnel independente (`crjm-macbookpro`, config
+`~/.cloudflared/config.yml`) que serve `wiki.infantinho.xyz` — **não partilham config
+nem processo**; alterações a um não afetam o outro.
+
+## Como foi criado
+
+Pré-requisitos: `cloudflared` instalado e `~/.cloudflared/cert.pem` (obtido uma vez com
+`cloudflared tunnel login`, autorizado para a zona `infantinho.xyz`).
+
+```bash
+# 1. Criar o tunnel (gera o UUID e o JSON de credenciais em ~/.cloudflared/)
+cloudflared tunnel create crjm
+
+# 2. Config dedicada — nunca editar o config.yml default (é do túnel do wiki)
+cat > ~/.cloudflared/config-crjm.yml <<'EOF'
+tunnel: fcb1352b-898e-4f0e-b96d-967e9a7e74e9
+credentials-file: /Users/igor/.cloudflared/fcb1352b-898e-4f0e-b96d-967e9a7e74e9.json
+
+ingress:
+  - hostname: crjm.infantinho.xyz
+    service: http://127.0.0.1:4000
+  - service: http_status:404
+EOF
+
+# 3. DNS — usar o UUID, NUNCA o nome (ver armadilha abaixo).
+#    --overwrite-dns porque já existia um CNAME órfão de um túnel antigo (devolvia 530).
+cloudflared tunnel route dns --overwrite-dns fcb1352b-898e-4f0e-b96d-967e9a7e74e9 crjm.infantinho.xyz
+```
+
+**⚠️ Armadilha confirmada:** `cloudflared tunnel route dns crjm …` resolveu o nome para
+o túnel errado (`crjm-macbookpro`, prefixo semelhante). Confirmar sempre no output
+`tunnelID=fcb1352b-…`; se apontar para outro, repetir o comando com o UUID.
+
+Nota: a criação via API REST não foi possível — o token em `~/.cloudflared/claude-token`
+é de curta duração e quase só de leitura. O fluxo API alternativo (requer token com
+`Cloudflare Tunnel:Edit` + `Zone:DNS:Edit`) está documentado na skill
+`~/.claude/skills/cloudflare-tunnel/SKILL.md`.
+
+## Operação
+
+Arranque (duas janelas de terminal, ou dois processos em background):
+
+```bash
+# 1. Servidor de torneios (lê ADMIN_KEY de .env.local automaticamente — Bun carrega .env.local)
+cd ~/dev/crjm && bun run tournament
+
+# 2. Conector do túnel
+cloudflared tunnel --config ~/.cloudflared/config-crjm.yml run
+```
+
+O conector está pronto quando o log mostra ≥2 linhas `Registered tunnel connection`.
+
+**Nenhum dos processos persiste a reboots** — não foi instalado LaunchAgent. Depois de
+reiniciar a máquina é preciso arrancar os dois de novo.
+
+Verificação rápida:
+
+```bash
+curl -s https://crjm.infantinho.xyz/health         # → {"status":"ok",...}
+curl -sI https://crjm.infantinho.xyz/admin         # → 401 (auth exigida, bom sinal)
+```
+
+Acesso ao painel de admin: `https://crjm.infantinho.xyz/admin`, utilizador `admin`,
+palavra-passe = valor de `ADMIN_KEY` em `.env.local` (ou header
+`Authorization: Bearer <ADMIN_KEY>`). Alunos e espectadores não precisam de credenciais.
+
+## Diagnóstico
+
+| Sintoma | Causa | Ação |
+| --- | --- | --- |
+| `530` no browser | Conector `cloudflared` em baixo | Arrancar o passo 2 da operação |
+| `502` | Conector ok, servidor de torneios em baixo | Arrancar `bun run tournament` |
+| `404` | Conector ok mas hostname não bate no ingress | Verificar `config-crjm.yml` |
+| `401` no admin | `ADMIN_KEY` errada | Confirmar valor em `.env.local` |
+
+`pgrep -fl cloudflared` distingue os dois conectores pelos argumentos (`--config …crjm…`
+vs. o do wiki, sem `--config`).
+
+## Remover o túnel
+
+```bash
+pkill -f 'config-crjm.yml'                                        # parar o conector
+cloudflared tunnel delete fcb1352b-898e-4f0e-b96d-967e9a7e74e9    # apaga tunnel + credenciais
+# O CNAME crjm.infantinho.xyz fica órfão — apagar no dashboard da Cloudflare.
+```


### PR DESCRIPTION
Novo guia em docs/deployment/tunnel-crjm-infantinho.md (criação, operação, diagnóstico e remoção do Cloudflare Tunnel para o servidor de torneios) e TORNEIO.md atualizado para usar o túnel permanente como opção recomendada.